### PR TITLE
Show two spaces for NQA004

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Error Codes
 | NQA001 | "`#noqa`" must have a single space after the hash, e.g. "`# noqa`" |
 | NQA002 | "`# noqa X000`" must have a colon, e.g. "`# noqa: X000`" |
 | NQA003 | "`# noqa : X000`" must not have a space before the colon, e.g. "# noqa: X000"' |
-| NQA004 | "`# noqa:  X000`" must have at most one space before the codes, e.g. "`# noqa: X000`" |
+| NQA004 | "`# noqa:␣␣X000`" must have at most one space before the codes, e.g. "`# noqa: X000`" |
 | NQA005 | "`# noqa: X000, X000`" has duplicate codes, remove X000 |
 | NQA011 | "`#flake8: noqa`" must have a single space after the hash, e.g. "`# flake8: noqa`" |
 | NQA012 | "`# flake8 noqa`" must have a colon or equals, e.g. "`# flake8: noqa`" |

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Error Codes
 | NQA001 | "`#noqa`" must have a single space after the hash, e.g. "`# noqa`" |
 | NQA002 | "`# noqa X000`" must have a colon, e.g. "`# noqa: X000`" |
 | NQA003 | "`# noqa : X000`" must not have a space before the colon, e.g. "# noqa: X000"' |
-| NQA004 | "`# noqa:␣␣X000`" must have at most one space before the codes, e.g. "`# noqa: X000`" |
+| NQA004 | "<code># noqa:&nbsp;&nbsp;X000</code>" must have at most one space before the codes, e.g. "`# noqa: X000`" |
 | NQA005 | "`# noqa: X000, X000`" has duplicate codes, remove X000 |
 | NQA011 | "`#flake8: noqa`" must have a single space after the hash, e.g. "`# flake8: noqa`" |
 | NQA012 | "`# flake8 noqa`" must have a colon or equals, e.g. "`# flake8: noqa`" |


### PR DESCRIPTION
Markdown renders two consecutive spaces as a single one which might lead to confusion in the table where there is no difference between correct and incorrect noqa comments.