### PR TITLE
Update flake8 dependency upper bound to 7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
 	package_data={'flake8_noqa': ['py.typed']},
 
 	install_requires=[
-		'flake8>=3.8.0,<6.0',
+		'flake8>=3.8.0,<7.0',
 		'importlib_metadata>=4.0.0,<5.0.0;python_version<"3.8.0"',
 		'typing_extensions>=3.7.4.2',
 	],


### PR DESCRIPTION
flake8 6 is out. Tests here pass with it, didn't test otherwise.

There's another upper bound in setup.py's dev extra, but that was already `<5.0` (and not `<6.0` like the main dep), so left that alone.